### PR TITLE
Make capitalisation of 'API' consistent

### DIFF
--- a/blog/2017/12/01/day-1-getting-started/index.markdown
+++ b/blog/2017/12/01/day-1-getting-started/index.markdown
@@ -37,7 +37,7 @@ Shoot I wasn't going to mention Perl!
 Yes, Mojolicious is written in Perl.
 Don't let that scare you.
 It has tons of ways to keep you and your code safe!
-From a built-in object system to a consistent api with chainable methods Mojolicious is designed to keep your code clean and readable.
+From a built-in object system to a consistent API with chainable methods, Mojolicious is designed to keep your code clean and readable.
 Hopefully you'll even have some fun using it!
 
 ## Installation

--- a/blog/2017/12/04/day-4-dont-fear-the-full-app/index.markdown
+++ b/blog/2017/12/04/day-4-dont-fear-the-full-app/index.markdown
@@ -111,7 +111,7 @@ Well ok so there is one small difference between Lite and Full, and that differe
 There are two other keywords, `under` and `group`.
 `under` allows routes share to code, like say for authentication.
 They also can share parts of their path.
-For example parts of an api that need authentication might be all under `/protected`.
+For example, parts of an API that need authentication might be all under `/protected`.
 
     get '/unsafe' => 'unsafe';
 
@@ -149,7 +149,7 @@ Full apps have it much easier!
 
 In a Full app, the route methods all return a new route object.
 If you store those in a variable, you can use them to build off of each other.
-This is a much more natural api for building nested structures in my opinion.
+This is a much more natural API for building nested structures in my opinion.
 
     my $r = $app->routes;
     $r->get('/unsafe' => 'unsafe');

--- a/blog/2017/12/06/day-6-adding-your-own-commands/index.markdown
+++ b/blog/2017/12/06/day-6-adding-your-own-commands/index.markdown
@@ -62,7 +62,7 @@ I'm going to copy portions of the code into this article for clarity, but consid
 Of course, we'll need some data.
 I've chosen to use <https://openweathermap.org/>
 To do run this you'll need to sign up for a [free account](http://home.openweathermap.org/users/sign_up).
-It only needs an email address, I tried but I really couldn't find a totally open access weather api.
+It only needs an email address, I tried but I really couldn't find a totally open access weather API.
 From there you can get an API key, which will need to go in a configuration file.
 Once you have it create a configuration file called `myweatherapp.conf` and fill it in like so:
 

--- a/blog/2017/12/08/day-8-mocking-a-rest-api/index.markdown
+++ b/blog/2017/12/08/day-8-mocking-a-rest-api/index.markdown
@@ -14,7 +14,7 @@ images:
         <a href="https://commons.wikimedia.org/w/index.php?curid=37564272">Image</a> by Calspan Corporation, National Highway Traffic Safety Administration - Public Domain.
 data:
   bio: preaction
-  description: 'Doug uses Mojolicious to quickly build a mock api for testing a front-end application.'
+  description: 'Doug uses Mojolicious to quickly build a mock API for testing a front-end application.'
 ---
 
 One of my applications is a pure-JavaScript UI for a JSON API. This UI


### PR DESCRIPTION
The capitalisation of 'API' varies throughout the calendar and in articles. This makes it consistent.. and adds some commas.